### PR TITLE
Get PHP docker image from GHCR, not Docker Hub

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
     test:
-        image: silintl/php8:8.3
+        image: ghcr.io/sil-org/php8:8.3
         volumes:
             - ./:/data
         working_dir: /data


### PR DESCRIPTION
### Fixed
- Get PHP docker image (for tests) from GHCR, not Docker Hub